### PR TITLE
Update civic.json file to new specification

### DIFF
--- a/civic.json
+++ b/civic.json
@@ -1,27 +1,47 @@
 {
-    "conformsTo": "http://codefordc.org/resources/specification.html",
-    "status": "Archival",
+    "name": "DC Handguns", 
+    "description": "Map of handgun ownership in the District of Columbia", 
+    "license": "BSD-3-CLAUSE", 
+    "status": "Archival", 
+    "type": "Map", 
+    "homepage": "http://cmgiven.github.io/dc-handguns/", 
+    "repository": "https://github.com/cmgiven/dc-handguns", 
+    "thumbnail": "", 
+    "geography": [
+        "Washington, DC"
+    ], 
     "contact": {
-        "name": "Chris Given",
-        "email": "cmgiven@gmail.com",
-        "twitter": "@cmgiven"
-    },
-    "bornAt": "Code for DC",
-    "geography": "Washington, DC",
-    "communityPartner": {
-        "WAMU 88.5": "http://wamu.org"
-    },
-    "type": "Map",
-    "data": {
-        "DC handgun ownership by zip code": "https://github.com/cmgiven/dc-handguns/tree/master/data"
-    },
-    "needs": [],
-    "categories": [
-        {"category":"Guns"},
-        {"category":"Handguns"},
-        {"category":"Concealed Carry"},
-        {"category":"Safety"},
-        {"category":"Crime"},
-        {"category":"Law"}
-    ]
+        "name": "Chris Given", 
+        "email": "cmgiven@gmail.com", 
+        "url": "https://twitter.com/@cmgiven"
+    }, 
+    "partners": [
+        {
+            "url": "http://wamu.org", 
+            "name": "WAMU 88.5", 
+            "email": ""
+        }, 
+        {
+            "url": "http://codefordc.org", 
+            "name": "Code for DC", 
+            "email": ""
+        }
+    ], 
+    "data": [
+        {
+            "url": "https://github.com/cmgiven/dc-handguns/tree/master/data", 
+            "name": "DC handgun ownership by zip code", 
+            "metadata": ""
+        }
+    ], 
+    "tags": [
+        "Guns", 
+        "Handguns", 
+        "Concealed Carry", 
+        "Safety", 
+        "Crime", 
+        "Law"
+    ], 
+    "links": [], 
+    "id": "https://raw.githubusercontent.com/DCgov/civic.json/master/schemas/schema-v1.json"
 }


### PR DESCRIPTION
Hi, there! Code for DC is moving to an updated civic.json
specification. This pull request formats your existing
civic.json to the new standard.

Feel free to look it over and make any updates.
# 

I also see that your repository has no license.
Without a license, others have no permission to use, modify, or share your code.

This site makes it easy to add an open source license: http://choosealicense.com/
# 

The new civic.json spec keeps the required fields from the older
one, but has a number of benefits. It:
- removes fields that are hard to maintain and get out of date quickly
- combines partner fields to be more broadly applicable
- is usable by civic tech projects outside of government, as well as inside

You'll see that DC Government is using this standard in its own repos:

https://github.com/dcgov

You can learn more about the specification requirements here:

http://open.dc.gov/civic.json
